### PR TITLE
Expand `~` in global gitignore path

### DIFF
--- a/src/pyastgrep/ignores.py
+++ b/src/pyastgrep/ignores.py
@@ -145,7 +145,8 @@ def find_gitignore_files(starting_path: Path, *, recurse_up: bool = True) -> lis
 
 def get_global_gitignore() -> Path | None:
     try:
-        return Path(subprocess.check_output(["git", "config", "--get", "core.excludesfile"], text=True).strip())
+        path = subprocess.check_output(["git", "config", "--get", "core.excludesfile"], text=True).strip()
+        return Path(path).expanduser()
     except Exception:
         # Most likely the user doesn't have git installed, or it's not configured
         # correctly. In this case we don't want to bug the user with irrelevant


### PR DESCRIPTION
On my machine, the `get_global_gitignore` function returns a path with a `~` in it, which causes an error when the file is opened:

    (Pdb) b get_global_gitignore
    Breakpoint 1 at ./env/lib/python3.8/site-packages/pyastgrep/ignores.py:146
    (Pdb) c
    ...snip...
    (Pdb) l
    142
    143         return files
    144
    145
    146 B   def get_global_gitignore() -> Path | None:
    147  ->     try:
    148             return Path(subprocess.check_output(["git", "config", "--get", "core.excludesfile"], text=True).strip())
    149         except Exception:
    150             # Most likely the user doesn't have git installed, or it's not configured
    151             # correctly. In this case we don't want to bug the user with irrelevant
    152             # warnings, so just ignore completely.
    (Pdb) unt
    > ./env/lib/python3.8/site-packages/pyastgrep/ignores.py(148)get_global_gitignore()
    -> return Path(subprocess.check_output(["git", "config", "--get", "core.excludesfile"], text=True).strip())
    (Pdb) subprocess.check_output(["git", "config", "--get", "core.excludesfile"], text=True)
    '~/.gitignore_global\n'
    (Pdb) c
    Traceback (most recent call last):
      File "/usr/lib/python3.8/pdb.py", line 1706, in main
        pdb._runscript(mainpyfile)
      File "/usr/lib/python3.8/pdb.py", line 1574, in _runscript
        self.run(statement)
      File "/usr/lib/python3.8/bdb.py", line 580, in run
        exec(cmd, globals, locals)
      File "<string>", line 1, in <module>
      File "./env/bin/pyastgrep", line 8, in <module>
        sys.exit(main())
      File "./env/lib/python3.8/site-packages/pyastgrep/cli.py", line 111, in main
        matches, errors = print_results(
      File "./env/lib/python3.8/site-packages/pyastgrep/printer.py", line 76, in print_results
        for result in results:
      File "./env/lib/python3.8/site-packages/pyastgrep/search.py", line 86, in search_python_files
        for path in get_files_to_search(paths):
      File "./env/lib/python3.8/site-packages/pyastgrep/files.py", line 18, in get_files_to_search
        walker = DirWalker(glob="*.py")
      File "./env/lib/python3.8/site-packages/pyastgrep/ignores.py", line 34, in __init__
        pathspecs.append(pathspec_for_gitignore(global_gitignore, is_global_gitignore=True))
      File "./env/lib/python3.8/site-packages/pyastgrep/ignores.py", line 110, in pathspec_for_gitignore
        with open(gitignore_file) as fp:
    FileNotFoundError: [Errno 2] No such file or directory: '~/.gitignore_global'